### PR TITLE
Show paths custom

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.3
+current_version = 2.1.4
 message = bump version → {new_version}
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def find_dev_required():
 
 setup(
     name="vedro-gitlab-reporter",
-    version="2.1.3",
+    version="2.1.4",
     description="GitLab reporter with collapsable sections for Vedro framework",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -57,7 +57,7 @@ async def fire_arg_parsed_event(dispatcher: Dispatcher, *,
                                 GitlabReporter.tb_show_internal_calls,
                                 tb_show_locals: bool =
                                 GitlabReporter.tb_show_locals,
-                                show_paths: bool =
+                                show_paths: Optional[list] =
                                 GitlabReporter.show_paths) -> None:
     await dispatcher.fire(ConfigLoadedEvent(Path(), Config))
 

--- a/tests/test_gitlab_reporter.py
+++ b/tests/test_gitlab_reporter.py
@@ -9,6 +9,7 @@ from vedro.events import (
     CleanupEvent,
     ScenarioFailedEvent,
     ScenarioPassedEvent,
+    ScenarioSkippedEvent,
     ScenarioReportedEvent,
     ScenarioRunEvent,
     StartupEvent,
@@ -145,9 +146,9 @@ async def test_scenario_passed_with_extra_details(*, dispatcher: Dispatcher, pri
 
 
 @pytest.mark.usefixtures(gitlab_reporter.__name__)
-async def test_scenario_passed_with_show_path(*, dispatcher: Dispatcher, printer_: Mock):
+async def test_scenario_passed_with_default_show_path(*, dispatcher: Dispatcher, printer_: Mock):
     with given:
-        await fire_arg_parsed_event(dispatcher, show_paths=True)
+        await fire_arg_parsed_event(dispatcher)
 
         scenario_result = make_scenario_result().mark_passed()
         await dispatcher.fire(ScenarioPassedEvent(scenario_result))
@@ -166,6 +167,53 @@ async def test_scenario_passed_with_show_path(*, dispatcher: Dispatcher, printer
                                         prefix=" "),
             call.print_scenario_extra_details([f"{aggregated_result.scenario.path.name}"],
                                               prefix=" " * 3)
+        ]
+
+
+@pytest.mark.usefixtures(gitlab_reporter.__name__)
+async def test_scenario_passed_with_none_show_path(*, dispatcher: Dispatcher, printer_: Mock):
+    with given:
+        await fire_arg_parsed_event(dispatcher, show_paths=None)
+
+        scenario_result = make_scenario_result().mark_passed()
+        await dispatcher.fire(ScenarioPassedEvent(scenario_result))
+
+        aggregated_result = make_aggregated_result(scenario_result)
+        event = ScenarioReportedEvent(aggregated_result)
+
+    with when:
+        await dispatcher.fire(event)
+
+    with then:
+        # no printed path of scenario info
+        assert printer_.mock_calls == [
+            call.print_scenario_subject(aggregated_result.scenario.subject,
+                                        ScenarioStatus.PASSED,
+                                        elapsed=aggregated_result.elapsed,
+                                        prefix=" "),
+        ]
+
+
+@pytest.mark.usefixtures(gitlab_reporter.__name__)
+async def test_scenario_passed_with_specified_show_path_not_included(*, dispatcher: Dispatcher, printer_: Mock):
+    with given:
+        await fire_arg_parsed_event(dispatcher, show_paths=[ScenarioStatus.FAILED])
+
+        scenario_result = make_scenario_result().mark_passed()
+        await dispatcher.fire(ScenarioPassedEvent(scenario_result))
+
+        aggregated_result = make_aggregated_result(scenario_result)
+        event = ScenarioReportedEvent(aggregated_result)
+
+    with when:
+        await dispatcher.fire(event)
+
+    with then:
+        assert printer_.mock_calls == [
+            call.print_scenario_subject(aggregated_result.scenario.subject,
+                                        ScenarioStatus.PASSED,
+                                        elapsed=aggregated_result.elapsed,
+                                        prefix=" "),
         ]
 
 
@@ -215,9 +263,9 @@ async def test_scenario_failed(*, dispatcher: Dispatcher, printer_: Mock):
 
 
 @pytest.mark.usefixtures(gitlab_reporter.__name__)
-async def test_scenario_failed_with_show_paths(*, dispatcher: Dispatcher, printer_: Mock):
+async def test_scenario_failed_with_default_show_paths(*, dispatcher: Dispatcher, printer_: Mock):
     with given:
-        await fire_arg_parsed_event(dispatcher, show_paths=True)
+        await fire_arg_parsed_event(dispatcher)
 
         scenario_result = make_scenario_result().mark_failed()
         await dispatcher.fire(ScenarioFailedEvent(scenario_result))
@@ -236,6 +284,30 @@ async def test_scenario_failed_with_show_paths(*, dispatcher: Dispatcher, printe
                                         prefix=" "),
             call.print_scenario_extra_details([f"{aggregated_result.scenario.path.name}"],
                                               prefix=" " * 3)
+        ]
+
+
+@pytest.mark.usefixtures(gitlab_reporter.__name__)
+async def test_scenario_failed_with_none_show_paths(*, dispatcher: Dispatcher, printer_: Mock):
+    with given:
+        await fire_arg_parsed_event(dispatcher, show_paths=None)
+
+        scenario_result = make_scenario_result().mark_failed()
+        await dispatcher.fire(ScenarioFailedEvent(scenario_result))
+
+        aggregated_result = make_aggregated_result(scenario_result)
+        event = ScenarioReportedEvent(aggregated_result)
+
+    with when:
+        await dispatcher.fire(event)
+
+    with then:
+        # no printed path of scenario info
+        assert printer_.mock_calls == [
+            call.print_scenario_subject(aggregated_result.scenario.subject,
+                                        ScenarioStatus.FAILED,
+                                        elapsed=aggregated_result.elapsed,
+                                        prefix=" "),
         ]
 
 

--- a/tests/test_gitlab_reporter.py
+++ b/tests/test_gitlab_reporter.py
@@ -194,7 +194,9 @@ async def test_scenario_passed_with_none_show_path(*, dispatcher: Dispatcher, pr
 
 
 @pytest.mark.usefixtures(gitlab_reporter.__name__)
-async def test_scenario_passed_with_specified_show_path_included(*, dispatcher: Dispatcher, printer_: Mock):
+async def test_scenario_passed_with_specified_show_path_included(
+    *, dispatcher: Dispatcher, printer_: Mock
+):
     with given:
         await fire_arg_parsed_event(dispatcher, show_paths=[ScenarioStatus.PASSED.value])
 
@@ -219,7 +221,9 @@ async def test_scenario_passed_with_specified_show_path_included(*, dispatcher: 
 
 
 @pytest.mark.usefixtures(gitlab_reporter.__name__)
-async def test_scenario_passed_with_specified_show_path_not_included(*, dispatcher: Dispatcher, printer_: Mock):
+async def test_scenario_passed_with_specified_show_path_not_included(
+    *, dispatcher: Dispatcher, printer_: Mock
+):
     with given:
         await fire_arg_parsed_event(dispatcher, show_paths=[ScenarioStatus.FAILED.value])
 

--- a/vedro_gitlab_reporter/__init__.py
+++ b/vedro_gitlab_reporter/__init__.py
@@ -1,5 +1,5 @@
 from ._collapsable_mode import GitlabCollapsableMode
 from ._gitlab_reporter import GitlabReporter, GitlabReporterPlugin
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"
 __all__ = ("GitlabReporter", "GitlabReporterPlugin", "GitlabCollapsableMode",)

--- a/vedro_gitlab_reporter/_gitlab_reporter.py
+++ b/vedro_gitlab_reporter/_gitlab_reporter.py
@@ -287,4 +287,4 @@ class GitlabReporter(PluginConfig):
     tb_max_frames: int = 8
 
     # Show the relative path of scenario in status
-    show_paths: list[ScenarioStatus] = []
+    show_paths: List[ScenarioStatus] = []

--- a/vedro_gitlab_reporter/_gitlab_reporter.py
+++ b/vedro_gitlab_reporter/_gitlab_reporter.py
@@ -80,19 +80,17 @@ class GitlabReporterPlugin(Reporter):
                            type=str.upper,
                            help="Show the relative path of scenario in status (failed or passed). "
                                 "--gitlab-show-paths - show all paths of scenarios; "
-                                "--gitlab-show-paths=failed passed - show all paths of scenarios;"
-                                "--gitlab-show-paths=failed - show all failed paths of scenarios;")
+                                "--gitlab-show-paths failed passed - show all paths of scenarios;"
+                                "--gitlab-show-paths failed - show all failed paths of scenarios;")
 
     def on_arg_parsed(self, event: ArgParsedEvent) -> None:
         self._collapsable_mode = event.args.gitlab_collapsable
         self._tb_show_internal_calls = event.args.gitlab_tb_show_internal_calls
         self._tb_show_locals = event.args.gitlab_tb_show_locals
 
-        if event.args.gitlab_show_paths == []:
-            # --gitlab-show-path -> gitlab_show_paths = [] -> all status
-            self._show_paths = [ScenarioStatus.FAILED, ScenarioStatus.PASSED]
-        else:
-            self._show_paths = event.args.gitlab_show_paths
+        # --gitlab-show-path -> default values (all)
+        self._show_paths = GitlabReporter.show_paths if event.args.gitlab_show_paths == [] \
+            else event.args.gitlab_show_paths
 
     def on_startup(self, event: StartupEvent) -> None:
         self._printer.print_header()
@@ -270,7 +268,7 @@ class GitlabReporterPlugin(Reporter):
             self._printer.print_scope_val(val)
 
     def _add_extra_details(self, scenario_result: ScenarioResult) -> None:
-        if self._show_paths and scenario_result.status in self._show_paths:
+        if self._show_paths and scenario_result.status.value in self._show_paths:
             scenario_result.add_extra_details(f"{scenario_result.scenario.rel_path}")
 
 
@@ -287,4 +285,4 @@ class GitlabReporter(PluginConfig):
     tb_max_frames: int = 8
 
     # Show the relative path of scenario in status
-    show_paths: list = [ScenarioStatus.FAILED, ScenarioStatus.PASSED]
+    show_paths: list = [status.value for status in [ScenarioStatus.FAILED, ScenarioStatus.PASSED]]


### PR DESCRIPTION
- `-r gitlab --gitlab-show-paths` -> print paths for all scenarios (skipped / passed)
```shell
➜  docker-compose exec  e2e /venv/bin/python3 bootstrap.py -r gitlab --gitlab-show-paths
Scenarios
* get options
 ✗ try to get options as guest (0.27s)
   |> scenarios/get_options/try_to_get_options_as_guest.py
   ✔ given_guest (0.00s)
   ...
   ✗ and_it_should_return_failure_body (0.00s)
...
AssertionError: assert False

 ✔ try to get options with empty feature (0.18s)
   |> scenarios/get_options/try_to_get_options_with_empty_feature.py
```
- `-r gitlab --gitlab-show-paths failed` -> print paths for specified scenarios (failed in example)
```shell
➜  docker-compose exec  e2e /venv/bin/python3 bootstrap.py -r gitlab --gitlab-show-paths failed
Scenarios
* get options
 ✗ try to get options as guest (0.29s)
   |> scenarios/get_options/try_to_get_options_as_guest.py
   ✔ given_guest (0.00s)
    ...
   ✗ and_it_should_return_failure_body (0.00s)
...
AssertionError: assert False

 ✔ try to get options with empty feature (0.21s)
```
- `-r gitlab` -> print no paths
```shell
➜  docker-compose exec  e2e /venv/bin/python3 bootstrap.py -r gitlab 
Scenarios
* get options
 ✗ try to get options as guest (0.25s)
   ✔ given_guest (0.00s)
   ...
   ✗ and_it_should_return_failure_body (0.00s)
AssertionError: assert False

 ✔ try to get options with empty feature (0.14s)
```